### PR TITLE
get a broker and list all brokers

### DIFF
--- a/k8s/service_controller/model/service_broker.go
+++ b/k8s/service_controller/model/service_broker.go
@@ -10,7 +10,7 @@ type ServiceBroker struct {
 	AuthPassword string
 	// SpaceGUID    string
 
-	Created int64
+	Created int64 `json:",string"`
 	Updated int64
 	SelfURL string
 }


### PR DESCRIPTION
 - stuffed the created int64 into a string because it does not
   round-trip correctly through k8s
 - left the debugging print statements in
 - k8s type that extends the model servicebroker type

Signed-off-by: Morgan Bauer <mbauer@us.ibm.com>